### PR TITLE
Add unit tests to increase coverage 

### DIFF
--- a/client/src/pages/Auth/Login.test.js
+++ b/client/src/pages/Auth/Login.test.js
@@ -47,95 +47,122 @@ describe('Login Component', () => {
     });
 
     it('renders login form', () => {
-        const { getByText, getByPlaceholderText } = render(
-          <MemoryRouter initialEntries={['/login']}>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-            </Routes>
-          </MemoryRouter>
-        );
-    
-        expect(getByText('LOGIN FORM')).toBeInTheDocument();
-        expect(getByPlaceholderText('Enter Your Email')).toBeInTheDocument();
-        expect(getByPlaceholderText('Enter Your Password')).toBeInTheDocument();
-      });
-      it('inputs should be initially empty', () => {
-        const { getByText, getByPlaceholderText } = render(
-          <MemoryRouter initialEntries={['/login']}>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-            </Routes>
-          </MemoryRouter>
-        );
-    
-        expect(getByText('LOGIN FORM')).toBeInTheDocument();
-        expect(getByPlaceholderText('Enter Your Email').value).toBe('');
-        expect(getByPlaceholderText('Enter Your Password').value).toBe('');
-      });
-    
-      it('should allow typing email and password', () => {
-        const { getByText, getByPlaceholderText } = render(
-          <MemoryRouter initialEntries={['/login']}>
-            <Routes>
-              <Route path="/login" element={<Login />} />
-            </Routes>
-          </MemoryRouter>
-        );
-        fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
-        fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
-        expect(getByPlaceholderText('Enter Your Email').value).toBe('test@example.com');
-        expect(getByPlaceholderText('Enter Your Password').value).toBe('password123');
-      });
+      const { getByText, getByPlaceholderText } = render(
+        <MemoryRouter initialEntries={['/login']}>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+          </Routes>
+        </MemoryRouter>
+      );
+  
+      expect(getByText('LOGIN FORM')).toBeInTheDocument();
+      expect(getByPlaceholderText('Enter Your Email')).toBeInTheDocument();
+      expect(getByPlaceholderText('Enter Your Password')).toBeInTheDocument();
+    });
       
+    it('inputs should be initially empty', () => {
+      const { getByText, getByPlaceholderText } = render(
+        <MemoryRouter initialEntries={['/login']}>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+          </Routes>
+        </MemoryRouter>
+      );
+  
+      expect(getByText('LOGIN FORM')).toBeInTheDocument();
+      expect(getByPlaceholderText('Enter Your Email').value).toBe('');
+      expect(getByPlaceholderText('Enter Your Password').value).toBe('');
+    });
+    
+    it('should allow typing email and password', () => {
+      const { getByText, getByPlaceholderText } = render(
+        <MemoryRouter initialEntries={['/login']}>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+          </Routes>
+        </MemoryRouter>
+      );
+      fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
+      fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
+      expect(getByPlaceholderText('Enter Your Email').value).toBe('test@example.com');
+      expect(getByPlaceholderText('Enter Your Password').value).toBe('password123');
+    });
+    
     it('should login the user successfully', async () => {
-        axios.post.mockResolvedValueOnce({
-            data: {
-                success: true,
-                user: { id: 1, name: 'John Doe', email: 'test@example.com' },
-                token: 'mockToken'
-            }
-        });
+      axios.post.mockResolvedValueOnce({
+          data: {
+              success: true,
+              user: { id: 1, name: 'John Doe', email: 'test@example.com' },
+              token: 'mockToken'
+          }
+      });
 
-        const { getByPlaceholderText, getByText } = render(
-            <MemoryRouter initialEntries={['/login']}>
-                <Routes>
-                    <Route path="/login" element={<Login />} />
-                </Routes>
-            </MemoryRouter>
-        );
+      const { getByPlaceholderText, getByText } = render(
+          <MemoryRouter initialEntries={['/login']}>
+              <Routes>
+                  <Route path="/login" element={<Login />} />
+              </Routes>
+          </MemoryRouter>
+      );
 
-        fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
-        fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
-        fireEvent.click(getByText('LOGIN'));
+      fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
+      fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
+      fireEvent.click(getByText('LOGIN'));
 
-        await waitFor(() => expect(axios.post).toHaveBeenCalled());
-        expect(toast.success).toHaveBeenCalledWith(undefined, {
-            duration: 5000,
-            icon: '🙏',
-            style: {
-                background: 'green',
-                color: 'white'
-            }
-        });
+      await waitFor(() => expect(axios.post).toHaveBeenCalled());
+      expect(toast.success).toHaveBeenCalledWith(undefined, {
+          duration: 5000,
+          icon: '🙏',
+          style: {
+              background: 'green',
+              color: 'white'
+          }
+      });
+    });
+
+    it('should display error toast for invalid password', async () => {
+      // Simulate a failed login attempt (wrong password)
+      axios.post.mockResolvedValueOnce({
+        data: {
+          success: false,
+          message: "Invalid password", // error message from API
+        },
+      });
+
+      const { getByPlaceholderText, getByText } = render(
+        <MemoryRouter initialEntries={['/login']}>
+            <Routes>
+                <Route path="/login" element={<Login />} />
+            </Routes>
+        </MemoryRouter>
+      );
+
+      fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
+      fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'wrongpassword' } });
+      fireEvent.click(getByText('LOGIN'));
+  
+      await waitFor(() => expect(axios.post).toHaveBeenCalled());
+      expect(toast.error).toHaveBeenCalledWith("Invalid password");
+      expect(toast.error).toHaveBeenCalledTimes(1);
     });
 
     it('should display error message on failed login', async () => {
-        axios.post.mockRejectedValueOnce({ message: 'Invalid credentials' });
+      axios.post.mockRejectedValueOnce({ message: 'Invalid credentials' });
 
-        const { getByPlaceholderText, getByText } = render(
-            <MemoryRouter initialEntries={['/login']}>
-                <Routes>
-                    <Route path="/login" element={<Login />} />
-                </Routes>
-            </MemoryRouter>
-        );
+      const { getByPlaceholderText, getByText } = render(
+          <MemoryRouter initialEntries={['/login']}>
+              <Routes>
+                  <Route path="/login" element={<Login />} />
+              </Routes>
+          </MemoryRouter>
+      );
 
-        fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
-        fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
-        fireEvent.click(getByText('LOGIN'));
+      fireEvent.change(getByPlaceholderText('Enter Your Email'), { target: { value: 'test@example.com' } });
+      fireEvent.change(getByPlaceholderText('Enter Your Password'), { target: { value: 'password123' } });
+      fireEvent.click(getByText('LOGIN'));
 
-        await waitFor(() => expect(axios.post).toHaveBeenCalled());
-        expect(toast.error).toHaveBeenCalledWith('Something went wrong');
+      await waitFor(() => expect(axios.post).toHaveBeenCalled());
+      expect(toast.error).toHaveBeenCalledWith('Something went wrong');
     });
 
     // Test for empty email field
@@ -180,7 +207,7 @@ describe('Login Component', () => {
           expect(axios.post).not.toHaveBeenCalled(); // Ensuring no request is sent
           expect(passwordInput).toHaveAttribute('required'); 
       });
-   });
+    });
 
     // Test for navigating to forgot password page
     it('should navigate to forgot password page', async () => {

--- a/client/src/pages/Auth/Register.test.js
+++ b/client/src/pages/Auth/Register.test.js
@@ -91,6 +91,52 @@ describe('Register Component', () => {
     );
   });
 
+  it('should show error message when email is already registered', async () => {
+    // simulating a response where the email is already registered
+    axios.post.mockResolvedValueOnce({
+      data: {
+        success: false,
+        message: "Already registered, please login", // error message from API
+      },
+    });
+
+    const { getByPlaceholderText } = render(
+      <MemoryRouter initialEntries={['/register']}>
+        <Routes>
+          <Route path="/register" element={<Register />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.change(getByPlaceholderText("Enter Your Name"), {
+      target: { value: "John Doe" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Email"), {
+      target: { value: "test@example.com" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Password"), {
+      target: { value: "password123" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Phone"), {
+      target: { value: "1234567890" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your Address"), {
+      target: { value: "123 Street" },
+    });
+    fireEvent.change(getByPlaceholderText("Enter Your DOB"), {
+      target: { value: "2000-01-01" },
+    });
+    fireEvent.change(getByPlaceholderText("What is Your Favorite sports"), {
+      target: { value: "Football" },
+    });
+
+    fireEvent.click(screen.getByText('REGISTER'));
+
+    await waitFor(() => expect(axios.post).toHaveBeenCalled());
+    expect(toast.error).toHaveBeenCalledWith("Already registered, please login");
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+
   it("should display error message on failed registration", async () => {
     axios.post.mockRejectedValueOnce({ message: "User already exists" });
 

--- a/controllers/authController.test.js
+++ b/controllers/authController.test.js
@@ -74,6 +74,75 @@ describe("User Controller Tests", () => {
       userId = user._id;
     });
 
+    it("should return error if email is missing", async () => {
+      req.body = {
+        name: mockUser.name,
+        password: mockUser.password,
+        phone: mockUser.phone,
+        address: mockUser.address,
+        answer: mockUser.answer,
+        role: mockUser.user,
+      };
+      await registerController(req, res);
+  
+      expect(res.send).toHaveBeenCalledWith({ message: "Email is Required" });
+    });
+
+    it("should return error if password is missing", async () => {
+      req.body = {
+        name: mockUser.name,
+        email: mockUser.email,
+        phone: mockUser.phone,
+        address: mockUser.address,
+        answer: mockUser.answer,
+        role: mockUser.user,
+      };
+      await registerController(req, res);
+  
+      expect(res.send).toHaveBeenCalledWith({ message: "Password is Required" });
+    });
+
+    it("should return error if Phone no is missing", async () => {
+      req.body = {
+        name: mockUser.name,
+        email: mockUser.email,
+        password: mockUser.password,
+        address: mockUser.address,
+        answer: mockUser.answer,
+        role: mockUser.user,
+      };
+      await registerController(req, res);
+  
+      expect(res.send).toHaveBeenCalledWith({ message: "Phone no is Required" });
+    });
+    it("should return error if address is missing", async () => {
+      req.body = {
+        name: mockUser.name,
+        email: mockUser.email,
+        password: mockUser.password,
+        phone: mockUser.phone,
+        answer: mockUser.answer,
+        role: mockUser.user,
+      };
+      await registerController(req, res);
+  
+      expect(res.send).toHaveBeenCalledWith({ message: "Address is Required" });
+    });
+
+    it("should return error if answer is missing", async () => {
+      req.body = {
+        name: mockUser.name,
+        email: mockUser.email,
+        password: mockUser.password,
+        phone: mockUser.phone,
+        address: mockUser.address,
+        role: mockUser.user,
+      };
+      await registerController(req, res);
+  
+      expect(res.send).toHaveBeenCalledWith({ message: "Answer is Required" });
+    });
+
     it("should not register an existing user", async () => {
       req.body = mockUser;
       await registerController(req, res);
@@ -86,7 +155,29 @@ describe("User Controller Tests", () => {
         })
       );
     });
-  });
+
+    it("should handle errors correctly", async () => {
+      // Mock console.log to track calls
+      jest.spyOn(console, "log").mockImplementation(() => {});
+  
+      // Mock res.send to throw an error
+      jest.spyOn(res, "send").mockImplementationOnce(() => {
+        throw new Error("Unexpected Error");
+      });
+  
+      await registerController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Errro in Registeration",
+        })
+      );
+    });
+
+
+  }); 
 
   describe("Login Controller", () => {
     it("should login a registered user", async () => {
@@ -98,6 +189,25 @@ describe("User Controller Tests", () => {
         expect.objectContaining({
           success: true,
           message: "login successfully",
+        })
+      );
+
+      token = res.send.mock.calls[0][0].token;
+    });
+
+    it("should fail a non registered user", async () => {
+      req.body = { email: "test@example.com", password: mockUser.password };
+
+      await loginController(req, res);
+
+      const user = await userModel.findOne({ email: "test@example.com" });
+      expect(user).not.toBeTruthy();
+
+      expect(res.status).toHaveBeenCalledWith(404);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Email is not registerd",
         })
       );
 
@@ -116,6 +226,28 @@ describe("User Controller Tests", () => {
         })
       );
     });
+
+    it("should handle errors correctly", async () => {
+      // Mock console.log to track calls
+      jest.spyOn(console, "log").mockImplementation(() => {});
+  
+      // Mock res.send to throw an error
+      jest.spyOn(res, "send").mockImplementationOnce(() => {
+        throw new Error("Unexpected Error");
+      });
+  
+      await loginController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Error in login",
+        })
+      );
+    });
+
+    
   });
 
   describe("Forgot Password Controller", () => {
@@ -152,6 +284,60 @@ describe("User Controller Tests", () => {
         })
       );
     });
+
+    it("should return error if email is missing", async () => {
+      req.body = {
+        answer: mockUser.answer,
+        newPassword: "newpassword123",
+      };
+      await forgotPasswordController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith({ message: "Emai is required" });
+    });
+
+    it("should return error if answer is missing", async () => {
+      req.body = {
+        email: mockUser.email,
+        newPassword: "newpassword123",
+      };
+      await forgotPasswordController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith({ message: "answer is required" });
+    });
+
+    it("should return error if password is missing", async () => {
+      req.body = {
+        email: mockUser.email,
+        answer: mockUser.answer,
+      };
+      await forgotPasswordController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith({ message: "New Password is required" });
+    });
+
+    it("should handle errors correctly", async () => {
+      // Mock console.log to track calls
+      jest.spyOn(console, "log").mockImplementation(() => {});
+  
+      // Mock res.send to throw an error
+      jest.spyOn(res, "send").mockImplementationOnce(() => {
+        throw new Error("Unexpected Error");
+      });
+  
+      await forgotPasswordController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(500);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Something went wrong",
+        })
+      );
+    });
+
   });
 
   describe("Test Protected Route", () => {
@@ -160,6 +346,24 @@ describe("User Controller Tests", () => {
 
       expect(res.send).toHaveBeenCalledWith("Protected Routes");
     });
+
+    it("should handle errors correctly", async () => {
+      // Mock console.log to track calls
+      jest.spyOn(console, "log").mockImplementation(() => {});
+  
+      // Mock res.send to throw an error
+      jest.spyOn(res, "send").mockImplementationOnce(() => {
+        throw new Error("Unexpected Error");
+      });
+  
+      await testController(req, res);
+  
+      expect(console.log).toHaveBeenCalledWith(expect.any(Error));
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ error: expect.any(Error) })
+      );
+    });
+    
   });
 
   describe("Update Profile Controller", () => {
@@ -180,5 +384,39 @@ describe("User Controller Tests", () => {
       const updatedUser = await userModel.findById(userId);
       expect(updatedUser.name).toBe("Updated User");
     });
+
+    it("should return an error if password is less than 6 characters", async () => {
+      req.body = {
+        name: "Updated User",
+        phone: "9876543210",
+        password: "123",
+      };
+      req.user = { _id: userId };
+  
+      await updateProfileController(req, res);
+
+      expect(res.json).toHaveBeenCalledWith({
+        error: "Passsword is required and 6 character long",
+      });
+    });
+
+    it("should return a 400 error when profile update fails", async () => {
+      req.body = { name: "Updated User", phone: "9876543210" };
+      req.user = { _id: userId };
+  
+      // Mock `findByIdAndUpdate` to throw an error
+      jest.spyOn(userModel, "findByIdAndUpdate").mockRejectedValueOnce(new Error("Database error"));
+  
+      await updateProfileController(req, res);
+  
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          success: false,
+          message: "Error WHile Update profile",
+        })
+      );
+    });
+
   });
 });


### PR DESCRIPTION
Add unit tests for login, register, authController

1.  write unit test for login page where user input wrong password

2. write unit test for register page where user input existing email

3. Add unit tests for error handling in authController
    - Add test cases for unsuccessful scenarios in the controller (e.g., missing required fields)
    - Ensure proper error messages and status codes are returned for missing fields