### PR TITLE
Add unit tests for Categories and update Jest config

### DIFF
--- a/client/src/hooks/useCategory.test.js
+++ b/client/src/hooks/useCategory.test.js
@@ -1,0 +1,98 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import axios from "axios";
+import useCategory from "./useCategory";
+
+jest.mock("axios");
+
+describe("useCategory Hook", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // To silence console.log for error test
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    console.log.mockRestore();
+  });
+
+  test("should fetch categories and return them", async () => {
+    const mockCategories = [
+      { _id: "1", name: "Electronics", slug: "electronics" },
+      { _id: "2", name: "Clothing", slug: "clothing" }
+    ];
+
+    axios.get.mockResolvedValueOnce({
+      data: { category: mockCategories }
+    });
+
+    const { result } = renderHook(() => useCategory());
+    expect(result.current).toEqual([]);
+
+    await waitFor(() => {
+      expect(result.current).toEqual(mockCategories);
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(1);
+    expect(axios.get).toHaveBeenCalledWith("/api/v1/category/get-category");
+  });
+
+  test("should handle API errors gracefully", async () => {
+    const mockError = new Error("API Error");
+    axios.get.mockRejectedValueOnce(mockError);
+
+    const { result } = renderHook(() => useCategory());
+    expect(result.current).toEqual([]);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    // Should still be an empty array
+    expect(result.current).toEqual([]);
+    expect(console.log).toHaveBeenCalledWith(mockError);
+  });
+
+  test("should handle empty category data", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { category: [] }
+    });
+
+    const { result } = renderHook(() => useCategory());
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  test("should handle undefined category data", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {}
+    });
+
+    const { result } = renderHook(() => useCategory());
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  test("should handle null category data", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { category: null }
+    });
+
+    const { result } = renderHook(() => useCategory());
+    expect(result.current).toEqual([]);
+
+    await waitFor(() => {
+      expect(axios.get).toHaveBeenCalledTimes(1);
+    });
+
+    expect(result.current).toEqual([]);
+  });
+}); 

--- a/client/src/pages/Categories.test.js
+++ b/client/src/pages/Categories.test.js
@@ -1,0 +1,89 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { BrowserRouter } from "react-router-dom";
+import Categories from "./Categories";
+import useCategory from "../hooks/useCategory";
+import Layout from "../components/Layout";
+
+// Mock useCategory hook
+jest.mock("../hooks/useCategory");
+
+// Mock Layout to avoid rendering Header which uses unmocked hooks
+jest.mock("../components/Layout", () => {
+  return {
+    __esModule: true,
+    default: ({ children, title }) => (
+      <div data-testid="mock-layout">
+        <div data-testid="layout-title">{title}</div>
+        {children}
+      </div>
+    ),
+  };
+});
+
+describe("Categories Component", () => {
+  const mockCategories = [
+    { _id: "1", name: "Electronics", slug: "electronics" },
+    { _id: "2", name: "Clothing", slug: "clothing" },
+    { _id: "3", name: "Books", slug: "books" },
+  ];
+
+  const renderCategoriesComponent = () => {
+    return render(
+      <BrowserRouter>
+        <Categories />
+      </BrowserRouter>
+    );
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("should render 'All Categories' title in Layout", () => {
+    useCategory.mockReturnValue(mockCategories);
+
+    renderCategoriesComponent();
+
+    expect(screen.getByTestId("layout-title")).toHaveTextContent("All Categories");
+  });
+
+  test("should render all categories from the hook", () => {
+    useCategory.mockReturnValue(mockCategories);
+
+    renderCategoriesComponent();
+
+    mockCategories.forEach((category) => {
+      expect(screen.getByText(category.name)).toBeInTheDocument();
+    });
+  });
+
+  test("should render the correct number of category links", () => {
+    useCategory.mockReturnValue(mockCategories);
+
+    renderCategoriesComponent();
+
+    const categoryLinks = screen.getAllByRole("link");
+    expect(categoryLinks).toHaveLength(mockCategories.length);
+  });
+
+  test("should generate correct links with proper slugs", () => {
+    useCategory.mockReturnValue(mockCategories);
+
+    renderCategoriesComponent();
+
+    mockCategories.forEach((category) => {
+      const link = screen.getByText(category.name);
+      expect(link).toHaveAttribute("href", `/category/${category.slug}`);
+    });
+  });
+
+  test("should handle empty categories array", () => {
+    useCategory.mockReturnValue([]);
+
+    renderCategoriesComponent();
+
+    const categoryLinks = screen.queryAllByRole("link");
+    expect(categoryLinks).toHaveLength(0);
+  });
+}); 

--- a/controllers/categoryController.test.js
+++ b/controllers/categoryController.test.js
@@ -4,6 +4,7 @@ const categoryModel = jest.fn();
 categoryModel.findOne = jest.fn();
 categoryModel.findByIdAndUpdate = jest.fn();
 categoryModel.findByIdAndDelete = jest.fn();
+categoryModel.find = jest.fn();
 
 // Use unstable_mockModule as it is ESM
 jest.unstable_mockModule('../models/categoryModel.js', () => ({
@@ -13,12 +14,16 @@ jest.unstable_mockModule('../models/categoryModel.js', () => ({
 let createCategoryController;
 let updateCategoryController;
 let deleteCategoryController;
+let categoryControlller;
+let singleCategoryController;
 
 beforeAll(async () => {
   const categoryControllerModule = await import("./categoryController.js");
   createCategoryController = categoryControllerModule.createCategoryController;
   updateCategoryController = categoryControllerModule.updateCategoryController;
   deleteCategoryController = categoryControllerModule.deleteCategoryCOntroller;
+  categoryControlller = categoryControllerModule.categoryControlller;
+  singleCategoryController = categoryControllerModule.singleCategoryController;
 });
 
 describe('createCategoryController', () => {
@@ -302,6 +307,142 @@ describe('deleteCategoryController', () => {
     expect(mockRes.send).toHaveBeenCalledWith({
       success: true,
       message: "Category Deleted Successfully",
+    });
+  });
+});
+
+// categoryControlller (get all categories)
+describe('categoryControlller', () => {
+  let mockReq;
+  let mockRes;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock request
+    mockReq = {};
+
+    // Mock response
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+  });
+
+  it('should get all categories successfully', async () => {
+    const mockCategories = [
+      { name: 'Category 1', slug: 'category-1' },
+      { name: 'Category 2', slug: 'category-2' }
+    ];
+    
+    categoryModel.find.mockResolvedValueOnce(mockCategories);
+
+    await categoryControlller(mockReq, mockRes);
+
+    expect(categoryModel.find).toHaveBeenCalledWith({});
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: true,
+      message: 'All Categories List',
+      category: mockCategories,
+    });
+  });
+
+  it('should handle database errors when fetching all categories', async () => {
+    const mockError = new Error('Database error');
+    categoryModel.find.mockRejectedValueOnce(mockError);
+
+    await categoryControlller(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: false,
+      error: mockError,
+      message: 'Error while getting all categories',
+    });
+  });
+
+  it('should return an empty array when no categories exist', async () => {
+    categoryModel.find.mockResolvedValueOnce([]);
+
+    await categoryControlller(mockReq, mockRes);
+
+    expect(categoryModel.find).toHaveBeenCalledWith({});
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: true,
+      message: 'All Categories List',
+      category: [],
+    });
+  });
+});
+
+// singleCategoryController
+describe('singleCategoryController', () => {
+  let mockReq;
+  let mockRes;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Mock request
+    mockReq = {
+      params: {
+        slug: 'test-category',
+      }
+    };
+
+    // Mock response
+    mockRes = {
+      status: jest.fn().mockReturnThis(),
+      send: jest.fn(),
+    };
+  });
+
+  it('should get a single category successfully', async () => {
+    const mockCategory = {
+      name: 'Test Category',
+      slug: 'test-category',
+    };
+    
+    categoryModel.findOne.mockResolvedValueOnce(mockCategory);
+
+    await singleCategoryController(mockReq, mockRes);
+
+    expect(categoryModel.findOne).toHaveBeenCalledWith({ slug: 'test-category' });
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: true,
+      message: 'Get SIngle Category SUccessfully',
+      category: mockCategory,
+    });
+  });
+
+  it('should handle case when category does not exist', async () => {
+    categoryModel.findOne.mockResolvedValueOnce(null);
+
+    await singleCategoryController(mockReq, mockRes);
+
+    expect(categoryModel.findOne).toHaveBeenCalledWith({ slug: 'test-category' });
+    expect(mockRes.status).toHaveBeenCalledWith(200);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: true,
+      message: 'Get SIngle Category SUccessfully',
+      category: null,
+    });
+  });
+
+  it('should handle database errors when fetching a single category', async () => {
+    const mockError = new Error('Database error');
+    categoryModel.findOne.mockRejectedValueOnce(mockError);
+
+    await singleCategoryController(mockReq, mockRes);
+
+    expect(mockRes.status).toHaveBeenCalledWith(500);
+    expect(mockRes.send).toHaveBeenCalledWith({
+      success: false,
+      error: mockError,
+      message: 'Error While getting Single Category',
     });
   });
 });

--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -6,11 +6,32 @@ export default {
   testEnvironment: "node",
 
   // which test to run
-  testMatch: ["<rootDir>/controllers/*.test.js"],
+  testMatch: [
+    "<rootDir>/controllers/*.test.js",
+    "<rootDir>/middlewares/*.test.js",
+    "<rootDir>/models/*.test.js",
+    "<rootDir>/config/*.test.js",
+    "<rootDir>/routes/*.test.js",
+    "<rootDir>/helpers/*.test.js"
+  ],
+
+  // setup files that run before Jest is loaded
+  setupFiles: [
+    "<rootDir>/jest.setup.js"
+  ],
 
   // jest code coverage
   collectCoverage: true,
-  collectCoverageFrom: ["controllers/**"],
+  collectCoverageFrom: [
+    "controllers/**", 
+    "middlewares/**", 
+    "models/**",
+    "config/**",
+    "routes/**",
+    "helpers/**"
+  ],
+  coverageDirectory: "coverage/backend",
+  coverageReporters: ["lcov", "text", "json"],
   coverageThreshold: {
     global: {
       lines: 100,

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -16,15 +16,41 @@ export default {
     "\\.(css|scss)$": "identity-obj-proxy",
   },
 
+  // setup files that run before Jest is loaded
+  setupFiles: [
+    "<rootDir>/jest.setup.js"
+  ],
+  
+  // setup files that run after Jest is loaded
+  setupFilesAfterEnv: [
+    "<rootDir>/client/src/setupTests.js"
+  ],
+
   // ignore all node_modules except styleMock (needed for css imports)
   transformIgnorePatterns: ["/node_modules/(?!(styleMock\\.js)$)"],
 
   // only run these tests
-  testMatch: ["<rootDir>/client/src/pages/Auth/*.test.js"],
+  testMatch: ["<rootDir>/client/src/**/*.test.js"],
+
+  // exclude directory
+  testPathIgnorePatterns: [
+    "<rootDir>/tests-examples/",
+    "<rootDir>/client/src/_markbind/",
+    "<rootDir>/client/src/_site/"
+  ],
 
   // jest code coverage
   collectCoverage: true,
-  collectCoverageFrom: ["client/src/pages/Auth/**"],
+  collectCoverageFrom: [
+    "client/src/**/*.js", 
+    "client/src/**/*.jsx",
+    "!tests-examples/**",
+    "!client/src/_markbind/**",
+    "!client/src/_site/**",
+    "!client/src/*.js"
+  ],
+  coverageDirectory: "coverage/frontend",
+  coverageReporters: ["lcov", "text", "json"],
   coverageThreshold: {
     global: {
       lines: 100,

--- a/models/categoryModel.test.js
+++ b/models/categoryModel.test.js
@@ -1,0 +1,92 @@
+import mongoose from "mongoose";
+import Category from "./categoryModel.js";
+import { MongoMemoryServer } from "mongodb-memory-server";
+
+describe("Category Model Test", () => {
+  let mongoServer;
+
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+  });
+
+  afterAll(async () => {
+    await mongoose.disconnect();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await Category.deleteMany({});
+  });
+
+  test("should create a category successfully", async () => {
+    const categoryData = {
+      name: "Electronics",
+      slug: "ELECTRONICS",
+    };
+
+    const createdCategory = await Category.create(categoryData);
+
+    expect(createdCategory._id).toBeDefined();
+    expect(createdCategory.name).toBe(categoryData.name);
+    expect(createdCategory.slug).toBe("electronics"); // Should be lowercase
+  });
+
+  test("should create a category with only name field", async () => {
+    const categoryData = {
+      name: "Books",
+    };
+
+    const createdCategory = await Category.create(categoryData);
+
+    expect(createdCategory._id).toBeDefined();
+    expect(createdCategory.name).toBe(categoryData.name);
+    expect(createdCategory.slug).toBeUndefined();
+  });
+
+  test("should convert slug to lowercase when provided in uppercase", async () => {
+    const categoryData = {
+      name: "Clothing",
+      slug: "CLOTHING-AND-ACCESSORIES",
+    };
+
+    const createdCategory = await Category.create(categoryData);
+    expect(createdCategory.slug).toBe("clothing-and-accessories");
+  });
+
+  test("should update a category successfully", async () => {
+    const categoryData = {
+      name: "Initial Name",
+      slug: "initial-slug",
+    };
+
+    const createdCategory = await Category.create(categoryData);
+    
+    createdCategory.name = "Updated Name";
+    createdCategory.slug = "UPDATED-SLUG";
+    await createdCategory.save();
+
+    // Fetch the updated category
+    const updatedCategory = await Category.findById(createdCategory._id);
+    
+    expect(updatedCategory.name).toBe("Updated Name");
+    expect(updatedCategory.slug).toBe("updated-slug"); // Should be lowercase
+  });
+
+  test("should delete a category successfully", async () => {
+    const categoryData = {
+      name: "To Be Deleted",
+      slug: "to-be-deleted",
+    };
+
+    const createdCategory = await Category.create(categoryData);
+
+    await Category.findByIdAndDelete(createdCategory._id);
+    
+    // Try to fetch the deleted category
+    const deletedCategory = await Category.findById(createdCategory._id);
+    
+    expect(deletedCategory).toBeNull();
+  });
+}); 

--- a/package.json
+++ b/package.json
@@ -56,21 +56,19 @@
     "sonarqube-scanner": "^3.3.0"
   },
   "jest": {
-    "testEnvironment": "jest-environment-jsdom",
-    "setupFilesAfterEnv": [
-      "<rootDir>/jest.setup.js"
+    "projects": [
+      "./jest.backend.config.js",
+      "./jest.frontend.config.js"
     ],
-    "transform": {
-      "^.+\\.jsx?$": "babel-jest"
-    },
-    "moduleNameMapper": {
-      "\\.(css|scss)$": "identity-obj-proxy"
-    },
-    "transformIgnorePatterns": [
-      "/node_modules/(?!(styleMock\\.js)$)"
-    ],
-    "setupFiles": [
-      "./jest.setup.js"
-    ]
+    "verbose": true,
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "coverageReporters": ["lcov", "text", "json", "html"],
+    "coverageThreshold": {
+      "global": {
+        "lines": 100,
+        "functions": 100
+      }
+    }
   }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
-# SonarQube server settings
+# SonarQube server settings - use your own token
 sonar.host.url=http://localhost:9000
-sonar.token=sqp_f8925cbd8654956df06bef97340260ae34c530f3
+sonar.token=
 
 # Project identification
 sonar.projectKey=econ
@@ -8,7 +8,17 @@ sonar.projectName=econ
 sonar.projectVersion=1.0
 
 # Analysis settings
-sonar.sources=client
+sonar.sources=client/src,config,controllers,helpers,middlewares,models,routes
 
+# Exclude test files from source analysis
+sonar.exclusions=**/*.test.js,**/*.spec.js,**/tests/**,**/tests-examples/**
 
-sonar.login=squ_ec55e838bf8fc91c8e3be0f7d7869bb5d2754252
+# JavaScript specific settings
+sonar.javascript.lcov.reportPaths=coverage/lcov.info,coverage/frontend/lcov.info,coverage/backend/lcov.info
+
+# Set test directories
+sonar.tests=client/src,controllers,middlewares,models,config,routes,helpers
+sonar.test.inclusions=**/*.test.js,**/*.spec.js
+
+# Coverage settings
+sonar.coverage.exclusions=**/node_modules/**,**/*.test.js,**/*.spec.js,**/tests/**,**/tests-examples/**


### PR DESCRIPTION
Includes unit tests for:
- hooks/useCategory.js
- pages/Categories.js
- controllers/categoryController.js
  - `categoryControlller`
  - `singleCategoryController`
- models/categoryModel.js

Update Jest config (frontend + backend) to test and cover relevant files
- `npm run test:frontend` and `npm run test:backend` tests frontend and backend separately
- `npm run test` tests for both frontend + backend using Jest built-in project support for parallel testing