### PR TITLE
Add unit tests for CategoryProduct and ProductDetails pages

### DIFF
--- a/client/src/pages/CategoryProduct.test.js
+++ b/client/src/pages/CategoryProduct.test.js
@@ -1,0 +1,243 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import axios from 'axios';
+import { BrowserRouter } from 'react-router-dom';
+import CategoryProduct from './CategoryProduct';
+
+// Mock axios
+jest.mock('axios');
+
+// Mock useParams and useNavigate
+jest.mock('react-router-dom', () => ({ 
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ slug: 'clothing' }),
+  useNavigate: () => jest.fn(),
+}));
+
+// Mock Layout to avoid rendering Header which uses unmocked hooks
+jest.mock("../components/Layout", () => {
+  return {
+    __esModule: true,
+    default: ({ children, title }) => (
+      <div data-testid="mock-layout">
+        <div data-testid="layout-title">{title}</div>
+        {children}
+      </div>
+    ),
+  };
+});
+
+describe('CategoryProduct Component', () => {
+  const mockProducts = [
+    {
+      _id: '1',
+      name: 'Jeans',
+      description: 'Blue like other jeans',
+      slug: 'jeans',
+      price: 22.07,
+    },
+    {
+      _id: '2',
+      name: 'T-shirt',
+      slug: 't-shirt',
+      description: 'Simple white tshirt',
+      price: 14.99,
+    },
+  ];
+
+  const mockCategory = {
+    name: 'Clothing',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders CategoryProduct component with loading state', async () => {
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+    
+    expect(screen.getByTestId('mock-layout')).toBeInTheDocument();
+    expect(screen.getByText('Category -')).toBeInTheDocument();
+    expect(screen.getByText('0 result found')).toBeInTheDocument();
+  });
+
+  test('fetches and displays products successfully', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        products: mockProducts,
+        category: mockCategory,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Category - Clothing')).toBeInTheDocument();
+      expect(screen.getByText('2 result found')).toBeInTheDocument();
+      expect(screen.getByText('Jeans')).toBeInTheDocument();
+      expect(screen.getByText('T-shirt')).toBeInTheDocument();
+    });
+
+    expect(axios.get).toHaveBeenCalledWith('/api/v1/product/product-category/clothing');
+  });
+
+  test('renders correctly when no products are found', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        products: [],
+        category: mockCategory,
+      },
+    });
+  
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+  
+    await waitFor(() => {
+      expect(screen.getByText('Category - Clothing')).toBeInTheDocument();
+      expect(screen.getByText('0 result found')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText('More Details')).not.toBeInTheDocument();
+  });
+
+  test('handles API error gracefully', async () => {
+    const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    const error = new Error('API Error');
+    axios.get.mockRejectedValueOnce(error);
+
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await waitFor(() => {
+      expect(consoleSpy).toHaveBeenCalledWith(error);
+    });
+
+    expect(screen.getByText('Category -')).toBeInTheDocument();
+    expect(screen.getByText('0 result found')).toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  test('renders product cards with correct formatting', async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        products: mockProducts,
+        category: mockCategory,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('$22.07')).toBeInTheDocument();
+      expect(screen.getByText('$14.99')).toBeInTheDocument();
+
+      expect(screen.getByText('Blue like other jeans...')).toBeInTheDocument();
+      expect(screen.getByText('Simple white tshirt...')).toBeInTheDocument();
+    });
+  });
+
+  test('description is correctly truncated to 60 characters with ellipsis', async () => {
+    const longDescriptionProduct = {
+      _id: '3',
+      name: 'Long Description Product',
+      slug: 'long-description',
+      description: 'This is a very long description that should be truncated at 60 characters to ensure proper display',
+      price: 29.99,
+    };
+
+    axios.get.mockResolvedValueOnce({
+      data: {
+        products: [longDescriptionProduct],
+        category: mockCategory,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await waitFor(() => {
+      const expectedTruncatedText = 'This is a very long description that should be truncated at ...';
+      expect(screen.getByText(expectedTruncatedText)).toBeInTheDocument();
+    });
+  });
+
+  test('navigates to product detail page when clicking More Details', async () => {
+    const mockNavigate = jest.fn();
+    jest.spyOn(require('react-router-dom'), 'useNavigate').mockReturnValue(mockNavigate);
+
+    axios.get.mockResolvedValueOnce({
+      data: {
+        products: mockProducts,
+        category: mockCategory,
+      },
+    });
+
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await act(async () => {
+      const moreDetailsButtons = screen.getAllByText('More Details');
+      fireEvent.click(moreDetailsButtons[0]);
+    });
+    
+    expect(mockNavigate).toHaveBeenCalledWith('/product/jeans');
+  });
+
+  test('should not fetch products when slug is undefined', async () => {
+    // Override the default useParams mock for this test
+    jest.spyOn(require('react-router-dom'), 'useParams').mockReturnValue({});
+  
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <CategoryProduct />
+        </BrowserRouter>
+      );
+    });
+
+    await waitFor(() => {
+      expect(axios.get).not.toHaveBeenCalled();
+    });
+  });
+}); 

--- a/client/src/pages/ProductDetails.js
+++ b/client/src/pages/ProductDetails.js
@@ -55,8 +55,7 @@ const ProductDetails = () => {
           <h6>Name : {product.name}</h6>
           <h6>Description : {product.description}</h6>
           <h6>
-            Price :
-            {product?.price?.toLocaleString("en-US", {
+            Price : {product?.price?.toLocaleString("en-US", {
               style: "currency",
               currency: "USD",
             })}

--- a/client/src/pages/ProductDetails.js
+++ b/client/src/pages/ProductDetails.js
@@ -61,7 +61,7 @@ const ProductDetails = () => {
             })}
           </h6>
           <h6>Category : {product?.category?.name}</h6>
-          <button class="btn btn-secondary ms-1">ADD TO CART</button>
+          <button className="btn btn-secondary ms-1">ADD TO CART</button>
         </div>
       </div>
       <hr />

--- a/client/src/pages/ProductDetails.test.js
+++ b/client/src/pages/ProductDetails.test.js
@@ -1,0 +1,291 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import axios from 'axios';
+import ProductDetails from './ProductDetails';
+
+// Mock axios
+jest.mock('axios');
+
+// Mock useParams and useNavigate
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ slug: 'test-product' }),
+  useNavigate: () => jest.fn(),
+}));
+
+// Mock Layout to avoid rendering Header which uses unmocked hooks
+jest.mock("../components/Layout", () => {
+  return {
+    __esModule: true,
+    default: ({ children, title }) => (
+      <div data-testid="mock-layout">
+        <div data-testid="layout-title">{title}</div>
+        {children}
+      </div>
+    ),
+  };
+});
+
+describe('ProductDetails Component', () => {
+  const mockProduct = {
+    _id: '123',
+    name: 'Jeans',
+    description: 'Blue like other jeans',
+    price: 22.07,
+    category: {
+      _id: 'cat123', 
+      name: 'Clothing'
+    },
+    slug: 'jeans'
+  };
+
+  const mockRelatedProducts = [
+    {
+      _id: '456',
+      name: 'Denim Jacket',
+      description: 'Denim jacket to match your jeans',
+      price: 39.99,
+      slug: 'denim-jacket'
+    },
+    {
+      _id: '789',
+      name: 'Cotton Tshirt',
+      description: 'Simple white tshirt',
+      price: 14.99,
+      slug: 'cotton-tshirt'
+    }
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should fetch and display product details on mount', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: mockRelatedProducts } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Product Details')).toBeInTheDocument();
+      expect(screen.getByText(`Name : ${mockProduct.name}`)).toBeInTheDocument();
+      expect(screen.getByText(`Description : ${mockProduct.description}`)).toBeInTheDocument();
+      expect(screen.getByText(`Category : ${mockProduct.category.name}`)).toBeInTheDocument();
+      expect(screen.getByText(`Price : $${mockProduct.price}`)).toBeInTheDocument();
+    });
+
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  test('should handle error when fetching product details', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    axios.get.mockRejectedValueOnce(new Error('Failed to fetch product'));
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+
+  test('should render related products section', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: mockRelatedProducts } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Similar Products ➡️')).toBeInTheDocument();
+      mockRelatedProducts.forEach(product => {
+        expect(screen.getByText(product.name)).toBeInTheDocument();
+      });
+    });
+  });
+
+  test('should display message when no related products found', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: [] } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('No Similar Products found')).toBeInTheDocument();
+    });
+  });
+
+  // test('should format product price correctly', async () => {
+  //   axios.get.mockImplementation((url) => {
+  //     if (url.includes('/get-product')) {
+  //       return Promise.resolve({ data: { product: mockProduct } });
+  //     } else if (url.includes('/related-product')) {
+  //       return Promise.resolve({ data: { products: [] } });
+  //     }
+  //     return Promise.reject(new Error('Invalid URL'));
+  //   });
+
+  //   render(
+  //     <BrowserRouter>
+  //       <ProductDetails />
+  //     </BrowserRouter>
+  //   );
+
+  //   await waitFor(() => {
+  //     expect(screen.getByText('Price : $22.07')).toBeInTheDocument();
+  //   });
+  // });
+
+  test('should handle error when fetching related products', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    
+    // First call succeed (get product), second call fail (related products)
+    axios.get
+      .mockResolvedValueOnce({ data: { product: mockProduct } })
+      .mockRejectedValueOnce(new Error('Failed to fetch related products'));
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(consoleLogSpy).toHaveBeenCalledWith(expect.any(Error));
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+
+  test('should truncate long descriptions in related products', async () => {
+    const longDescriptionProduct = {
+      ...mockRelatedProducts[0],
+      description: 'This is a very long description that should be truncated at 60 characters to ensure proper display'
+    };
+
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: [longDescriptionProduct] } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      const truncatedText = longDescriptionProduct.description.substring(0, 60) + '...';
+      expect(screen.getByText(truncatedText)).toBeInTheDocument();
+    });
+  });
+
+  test('should render product images with correct src and alt text', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: mockRelatedProducts } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      const mainImage = screen.getByRole('img', { name: mockProduct.name });  // look for alt text
+      expect(mainImage).toBeInTheDocument();
+      expect(mainImage.src).toContain(`/api/v1/product/product-photo/${mockProduct._id}`);  // check if src is correct
+
+      mockRelatedProducts.forEach(product => {
+        const relatedImage = screen.getByRole('img', { name: product.name });  // look for alt text
+        expect(relatedImage).toBeInTheDocument();
+        expect(relatedImage.src).toContain(`/api/v1/product/product-photo/${product._id}`);  // check if src is correct
+      });
+    });
+  });
+
+  test('should navigate to related product when clicking More Details', async () => {
+    const mockNavigate = jest.fn();
+    jest.spyOn(require('react-router-dom'), 'useNavigate').mockImplementation(() => mockNavigate);
+
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product')) {
+        return Promise.resolve({ data: { products: mockRelatedProducts } });
+      }
+      return Promise.reject(new Error('Invalid URL'));
+    });
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      const moreDetailsButtons = screen.getAllByText('More Details');
+      fireEvent.click(moreDetailsButtons[0]);
+      expect(mockNavigate).toHaveBeenCalledWith(`/product/${mockRelatedProducts[0].slug}`);
+    });
+  });
+
+  test('should not fetch product when slug parameter is missing', async () => {
+    // Override the default useParams mock for this test
+    jest.spyOn(require('react-router-dom'), 'useParams').mockReturnValue({});
+    
+    const axiosGetSpy = jest.spyOn(axios, 'get');
+
+    render(
+      <BrowserRouter>
+        <ProductDetails />
+      </BrowserRouter>
+    );
+
+    expect(axiosGetSpy).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/ProductDetails.test.js
+++ b/client/src/pages/ProductDetails.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import axios from 'axios';
 import ProductDetails from './ProductDetails';
@@ -71,11 +71,13 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Product Details')).toBeInTheDocument();
@@ -92,11 +94,13 @@ describe('ProductDetails Component', () => {
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
     axios.get.mockRejectedValueOnce(new Error('Failed to fetch product'));
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       expect(consoleLogSpy).toHaveBeenCalledWith(expect.any(Error));
@@ -115,11 +119,13 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('Similar Products ➡️')).toBeInTheDocument();
@@ -139,37 +145,18 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       expect(screen.getByText('No Similar Products found')).toBeInTheDocument();
     });
   });
-
-  // test('should format product price correctly', async () => {
-  //   axios.get.mockImplementation((url) => {
-  //     if (url.includes('/get-product')) {
-  //       return Promise.resolve({ data: { product: mockProduct } });
-  //     } else if (url.includes('/related-product')) {
-  //       return Promise.resolve({ data: { products: [] } });
-  //     }
-  //     return Promise.reject(new Error('Invalid URL'));
-  //   });
-
-  //   render(
-  //     <BrowserRouter>
-  //       <ProductDetails />
-  //     </BrowserRouter>
-  //   );
-
-  //   await waitFor(() => {
-  //     expect(screen.getByText('Price : $22.07')).toBeInTheDocument();
-  //   });
-  // });
 
   test('should handle error when fetching related products', async () => {
     const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -179,11 +166,13 @@ describe('ProductDetails Component', () => {
       .mockResolvedValueOnce({ data: { product: mockProduct } })
       .mockRejectedValueOnce(new Error('Failed to fetch related products'));
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       expect(consoleLogSpy).toHaveBeenCalledWith(expect.any(Error));
@@ -207,11 +196,13 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       const truncatedText = longDescriptionProduct.description.substring(0, 60) + '...';
@@ -229,11 +220,13 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
     await waitFor(() => {
       const mainImage = screen.getByRole('img', { name: mockProduct.name });  // look for alt text
@@ -261,31 +254,36 @@ describe('ProductDetails Component', () => {
       return Promise.reject(new Error('Invalid URL'));
     });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
-    await waitFor(() => {
+    await act(async () => {
       const moreDetailsButtons = screen.getAllByText('More Details');
       fireEvent.click(moreDetailsButtons[0]);
-      expect(mockNavigate).toHaveBeenCalledWith(`/product/${mockRelatedProducts[0].slug}`);
     });
+
+    expect(mockNavigate).toHaveBeenCalledWith(`/product/${mockRelatedProducts[0].slug}`);
   });
 
   test('should not fetch product when slug parameter is missing', async () => {
     // Override the default useParams mock for this test
     jest.spyOn(require('react-router-dom'), 'useParams').mockReturnValue({});
     
-    const axiosGetSpy = jest.spyOn(axios, 'get');
+    await act(async () => {
+      render(
+        <BrowserRouter>
+          <ProductDetails />
+        </BrowserRouter>
+      );
+    });
 
-    render(
-      <BrowserRouter>
-        <ProductDetails />
-      </BrowserRouter>
-    );
-
-    expect(axiosGetSpy).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(axios.get).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
Includes unit tests for:
- pages/ProductDetails.js
- pages/CategoryProduct.js

Fix Invalid DOM property `class` error in `pages/ProductDetails.js` button