### PR TITLE
Add integration tests for ProductDetails page

### DIFF
--- a/client/src/pages/ProductDetails.integration.test.js
+++ b/client/src/pages/ProductDetails.integration.test.js
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter } from 'react-router-dom';
+import axios from 'axios';
+import ProductDetails from './ProductDetails';
+import { CartProvider } from '../context/cart';
+
+jest.mock('axios');
+
+jest.mock('react-hot-toast', () => ({
+  success: jest.fn(),
+  error: jest.fn(),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useParams: () => ({ slug: 'test-product' }),
+  useNavigate: () => jest.fn(),
+}));
+
+jest.mock('../context/auth', () => ({
+  useAuth: () => [{ user: { name: 'Test User' } }, jest.fn()],
+}));
+
+jest.mock('../hooks/useCategory', () => () => [
+  { _id: 'category1', name: 'Test Category' }
+]);
+
+jest.mock('../components/Layout', () => ({ children }) => <div>{children}</div>);
+
+describe('ProductDetails Integration Tests', () => {
+  const mockProduct = {
+    _id: 'product1',
+    name: 'Jeans',
+    description: 'Blue like other jeans',
+    price: 22.07,
+    category: {
+      _id: 'cat1', 
+      name: 'Clothing'
+    },
+    slug: 'jeans'
+  };
+
+  const mockRelatedProducts = [
+    {
+      _id: 'related1',
+      name: 'Denim Jacket',
+      description: 'Denim jacket to match your jeans',
+      price: 39.99,
+      category: { _id: 'cat1', name: 'Clothing' },
+      slug: 'denim-jacket',
+    },
+    {
+      _id: 'related2',
+      name: 'White Sneakers',
+      description: 'Classic white sneakers for a casual look.',
+      price: 59.99,
+      category: { _id: 'cat2', name: 'Footwear' },
+      slug: 'white-sneakers',
+    }
+  ];
+
+  const localStorageMock = (() => {
+    let store = {};
+    return {
+      getItem: jest.fn((key) => store[key] || null),
+      setItem: jest.fn((key, value) => {
+        store[key] = value.toString();
+      }),
+      clear: jest.fn(() => {
+        store = {};
+      }),
+    };
+  })();
+  Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorageMock.clear();
+
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/get-product/')) {
+        return Promise.resolve({ data: { product: mockProduct } });
+      } else if (url.includes('/related-product/')) {
+        return Promise.resolve({ data: { products: mockRelatedProducts } });
+      }
+      return Promise.reject(new Error('Not found'));
+    });
+  });
+
+  test('should fetch and display product details', async () => {
+    render(
+      <BrowserRouter>
+        <CartProvider>
+          <ProductDetails />
+        </CartProvider>
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Product Details')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(`Name : ${mockProduct.name}`)).toBeInTheDocument();
+      expect(screen.getByText(`Description : ${mockProduct.description}`)).toBeInTheDocument();
+      expect(screen.getByText(`Category : ${mockProduct.category.name}`)).toBeInTheDocument();
+      expect(screen.getByText(`Price : $${mockProduct.price}`)).toBeInTheDocument();
+    });
+  });
+
+  test('should fetch and display similar products', async () => {
+    render(
+      <BrowserRouter>
+        <CartProvider>
+          <ProductDetails />
+        </CartProvider>
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Similar Products ➡️')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(mockRelatedProducts[0].name)).toBeInTheDocument();
+      expect(screen.getByText(mockRelatedProducts[1].name)).toBeInTheDocument();
+
+      const truncatedDesc = mockRelatedProducts[0].description.substring(0, 60) + '...';
+      expect(screen.getByText(truncatedDesc)).toBeInTheDocument();
+    });
+  });
+
+  test('should add main product to cart when ADD TO CART button is clicked', async () => {
+    render(
+      <BrowserRouter>
+        <CartProvider>
+          <ProductDetails />
+        </CartProvider>
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Product Details')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { level: 6, name: new RegExp(mockProduct.name) })).toBeInTheDocument();
+    });
+
+    const addToCartButtons = screen.getAllByRole('button', { name: /ADD TO CART/i });
+    fireEvent.click(addToCartButtons[0]);
+
+    await waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalled();
+      const cartData = JSON.parse(localStorageMock.setItem.mock.calls[0][1]);
+      expect(cartData).toEqual(expect.arrayContaining([
+        expect.objectContaining({ _id: mockProduct._id })
+      ]));
+    });
+  });
+
+  test('should add similar product to cart when ADD TO CART button is clicked', async () => {
+    render(
+      <BrowserRouter>
+        <CartProvider>
+          <ProductDetails />
+        </CartProvider>
+      </BrowserRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Similar Products ➡️')).toBeInTheDocument();
+      expect(screen.getByText(mockRelatedProducts[0].name)).toBeInTheDocument();
+    });
+
+    const addToCartButtons = screen.getAllByRole('button', { name: /ADD TO CART/i });
+    fireEvent.click(addToCartButtons[1]);
+
+    await waitFor(() => {
+      expect(localStorageMock.setItem).toHaveBeenCalled();
+      const cartData = JSON.parse(localStorageMock.setItem.mock.calls[0][1]);
+      expect(cartData).toEqual(expect.arrayContaining([
+        expect.objectContaining({ _id: mockRelatedProducts[0]._id })
+      ]));
+    });
+  });
+}); 

--- a/client/src/pages/ProductDetails.js
+++ b/client/src/pages/ProductDetails.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from "react";
 import Layout from "./../components/Layout";
 import axios from "axios";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import "../styles/ProductDetailsStyles.css";
 import { useCart } from "../context/cart";
 import { toast } from "react-hot-toast";
@@ -11,35 +11,83 @@ const ProductDetails = () => {
   const navigate = useNavigate();
   const [product, setProduct] = useState({});
   const [relatedProducts, setRelatedProducts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
   const [cart = [], setCart = () => {}] = useCart() || [];
 
-  //inital details
+  //initial details
   useEffect(() => {
     if (params?.slug) getProduct();
   }, [params?.slug]);
+  
   //getProduct
   const getProduct = async () => {
     try {
+      setLoading(true);
       const { data } = await axios.get(
         `/api/v1/product/get-product/${params.slug}`
       );
-      setProduct(data?.product);
-      getSimilarProduct(data?.product._id, data?.product.category._id);
+      
+      if (!data?.product) {
+        setNotFound(true);
+        setLoading(false);
+        return;
+      }
+      
+      setProduct(data.product);
+      getSimilarProduct(data.product._id, data.product.category._id);
+      setLoading(false);
     } catch (error) {
       console.log(error);
+      setNotFound(true);
+      setLoading(false);
     }
   };
+  
   //get similar product
   const getSimilarProduct = async (pid, cid) => {
     try {
       const { data } = await axios.get(
         `/api/v1/product/related-product/${pid}/${cid}`
       );
-      setRelatedProducts(data?.products);
+      setRelatedProducts(data?.products || []);
     } catch (error) {
       console.log(error);
     }
   };
+  
+  // Product not found UI
+  if (notFound) {
+    return (
+      <Layout title="Product Not Found">
+        <div className="container text-center mt-5">
+          <div className="error-container">
+            <h1>Product not found</h1>
+            <p className="lead">The requested product does not exist or may have been removed.</p>
+            <Link to="/" className="btn btn-primary mt-3">
+              Continue Shopping
+            </Link>
+          </div>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Loading UI
+  if (loading) {
+    return (
+      <Layout>
+        <div className="container text-center mt-5">
+          <div className="spinner-border" role="status">
+            <span className="visually-hidden">Loading...</span>
+          </div>
+          <p className="mt-3">Loading product details...</p>
+        </div>
+      </Layout>
+    );
+  }
+
+  // Main product details UI
   return (
     <Layout>
       <div className="row container product-details">
@@ -72,7 +120,7 @@ const ProductDetails = () => {
                 "cart",
                 JSON.stringify([...cart, product])
               );
-              // toast.success("Item added to cart");
+              toast.success("Item added to cart");
             }}
           >
             ADD TO CART
@@ -121,7 +169,7 @@ const ProductDetails = () => {
                         "cart",
                         JSON.stringify([...cart, p])
                       );
-                      // toast.success("Item Added to cart");
+                      toast.success("Item Added to cart");
                     }}
                   >
                     ADD TO CART

--- a/client/src/pages/ProductDetails.js
+++ b/client/src/pages/ProductDetails.js
@@ -3,12 +3,15 @@ import Layout from "./../components/Layout";
 import axios from "axios";
 import { useParams, useNavigate } from "react-router-dom";
 import "../styles/ProductDetailsStyles.css";
+import { useCart } from "../context/cart";
+import { toast } from "react-hot-toast";
 
 const ProductDetails = () => {
   const params = useParams();
   const navigate = useNavigate();
   const [product, setProduct] = useState({});
   const [relatedProducts, setRelatedProducts] = useState([]);
+  const [cart = [], setCart = () => {}] = useCart() || [];
 
   //inital details
   useEffect(() => {
@@ -61,7 +64,19 @@ const ProductDetails = () => {
             })}
           </h6>
           <h6>Category : {product?.category?.name}</h6>
-          <button className="btn btn-secondary ms-1">ADD TO CART</button>
+          <button 
+            className="btn btn-secondary ms-1"
+            onClick={() => {
+              setCart([...cart, product]);
+              localStorage.setItem(
+                "cart",
+                JSON.stringify([...cart, product])
+              );
+              // toast.success("Item added to cart");
+            }}
+          >
+            ADD TO CART
+          </button>
         </div>
       </div>
       <hr />
@@ -98,19 +113,19 @@ const ProductDetails = () => {
                   >
                     More Details
                   </button>
-                  {/* <button
-                  className="btn btn-dark ms-1"
-                  onClick={() => {
-                    setCart([...cart, p]);
-                    localStorage.setItem(
-                      "cart",
-                      JSON.stringify([...cart, p])
-                    );
-                    toast.success("Item Added to cart");
-                  }}
-                >
-                  ADD TO CART
-                </button> */}
+                  <button
+                    className="btn btn-dark ms-1"
+                    onClick={() => {
+                      setCart([...cart, p]);
+                      localStorage.setItem(
+                        "cart",
+                        JSON.stringify([...cart, p])
+                      );
+                      // toast.success("Item Added to cart");
+                    }}
+                  >
+                    ADD TO CART
+                  </button>
                 </div>
               </div>
             </div>

--- a/jest.backend.config.js
+++ b/jest.backend.config.js
@@ -14,6 +14,11 @@ export default {
     "<rootDir>/routes/*.test.js",
     "<rootDir>/helpers/*.test.js"
   ],
+  
+  // explicitly exclude integration tests
+  testPathIgnorePatterns: [
+    ".*\\.integration\\.test\\.js$"
+  ],
 
   // setup files that run before Jest is loaded
   setupFiles: [
@@ -28,7 +33,8 @@ export default {
     "models/**",
     "config/**",
     "routes/**",
-    "helpers/**"
+    "helpers/**",
+    "!**/*.integration.test.js"
   ],
   coverageDirectory: "coverage/backend",
   coverageReporters: ["lcov", "text", "json"],

--- a/jest.backend.integration.config.js
+++ b/jest.backend.integration.config.js
@@ -1,0 +1,34 @@
+export default {
+  "displayName": "backend-integration",
+  "testEnvironment": "node",
+  "testMatch": [
+    "<rootDir>/controllers/*.integration.test.js",
+    "<rootDir>/middlewares/*.integration.test.js",
+    "<rootDir>/models/*.integration.test.js",
+    "<rootDir>/config/*.integration.test.js",
+    "<rootDir>/routes/*.integration.test.js",
+    "<rootDir>/helpers/*.integration.test.js"
+  ],
+  "setupFiles": [
+    "<rootDir>/jest.setup.js"
+  ],
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "controllers/**",
+    "middlewares/**",
+    "models/**",
+    "config/**",
+    "routes/**",
+    "helpers/**",
+    "!**/*.test.js",
+    "**/*.integration.test.js"
+  ],
+  "coverageDirectory": "coverage/backend-integration",
+  "coverageReporters": ["lcov", "text", "json"],
+  "coverageThreshold": {
+    "global": {
+      "lines": 80,
+      "functions": 80
+    }
+  }
+}

--- a/jest.frontend.config.js
+++ b/jest.frontend.config.js
@@ -32,11 +32,12 @@ export default {
   // only run these tests
   testMatch: ["<rootDir>/client/src/**/*.test.js"],
 
-  // exclude directory
+  // exclude directory and integration tests
   testPathIgnorePatterns: [
     "<rootDir>/tests-examples/",
     "<rootDir>/client/src/_markbind/",
-    "<rootDir>/client/src/_site/"
+    "<rootDir>/client/src/_site/",
+    ".*\\.integration\\.test\\.js$"
   ],
 
   // jest code coverage
@@ -47,7 +48,8 @@ export default {
     "!tests-examples/**",
     "!client/src/_markbind/**",
     "!client/src/_site/**",
-    "!client/src/*.js"
+    "!client/src/*.js",
+    "!**/*.integration.test.js"
   ],
   coverageDirectory: "coverage/frontend",
   coverageReporters: ["lcov", "text", "json"],

--- a/jest.frontend.integration.config.js
+++ b/jest.frontend.integration.config.js
@@ -1,0 +1,40 @@
+export default {
+  "displayName": "frontend-integration",
+  "testEnvironment": "jest-environment-jsdom",
+  "transform": {
+    "^.+\\.jsx?$": "babel-jest"
+  },
+  "moduleNameMapper": {
+    "\\.(css|scss)$": "identity-obj-proxy"
+  },
+  "setupFiles": [
+    "<rootDir>/jest.setup.js"
+  ],
+  "testMatch": [
+    "<rootDir>/client/src/**/*.integration.test.js"
+  ],
+  "testPathIgnorePatterns": [
+    "<rootDir>/tests-examples/",
+    "<rootDir>/client/src/_markbind/",
+    "<rootDir>/client/src/_site/"
+  ],
+  "collectCoverage": true,
+  "collectCoverageFrom": [
+    "client/src/**/*.js",
+    "client/src/**/*.jsx",
+    "!tests-examples/**",
+    "!client/src/_markbind/**",
+    "!client/src/_site/**",
+    "!client/src/*.js",
+    "!**/*.test.js",
+    "**/*.integration.test.js"
+  ],
+  "coverageDirectory": "coverage/frontend-integration",
+  "coverageReporters": ["lcov", "text", "json"],
+  "coverageThreshold": {
+    "global": {
+      "lines": 80,
+      "functions": 80
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "sonarqube": "sonar-scanner",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "test:frontend": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.frontend.config.js",
-    "test:backend": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.backend.config.js"
+    "test:backend": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.backend.config.js",
+    "test:backend-integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.backend.integration.config.js",
+    "test:frontend-integration": "node --experimental-vm-modules node_modules/jest/bin/jest.js --config jest.frontend.integration.config.js"
   },
   "keywords": [],
   "author": "RP",
@@ -58,7 +60,9 @@
   "jest": {
     "projects": [
       "./jest.backend.config.js",
-      "./jest.frontend.config.js"
+      "./jest.frontend.config.js",
+      "./jest.frontend.integration.config.js",
+      "./jest.backend.integration.config.js"
     ],
     "verbose": true,
     "collectCoverage": true,


### PR DESCRIPTION
### `ProductDetails.js`
- Integration tests for viewing products
- Implement add to cart functionality
- Add product not found UI (can't find product in DB, or `product` in response is `null`)

### Testing
- Introduce `npm run test:frontend-integration` and `npm run test:backend-integration` to run only integration tests
- `npm run test:frontend` and `npm run test:backend` only runs unit tests
- `npm run test` runs all frontend and backend tests (unit and integration)