### PR TITLE
Add integration tests for categoryController

### DIFF
--- a/controllers/categoryController.integration.test.js
+++ b/controllers/categoryController.integration.test.js
@@ -1,0 +1,120 @@
+// tests/integration/categoryController.integration.test.js
+import mongoose from "mongoose";
+import { MongoMemoryServer } from "mongodb-memory-server";
+import app from "../app";
+import categoryModel from "../models/categoryModel.js";
+import request from "supertest";
+
+describe("Category Controller Integration Tests", () => {
+  let mongoServer;
+  
+  beforeAll(async () => {
+    mongoServer = await MongoMemoryServer.create();
+    const mongoUri = mongoServer.getUri();
+    await mongoose.connect(mongoUri);
+  });
+  
+  afterAll(async () => {
+    await mongoose.connection.close();
+    await mongoServer.stop();
+  });
+
+  beforeEach(async () => {
+    await categoryModel.create([
+      { name: "Electronics", slug: "electronics" },
+      { name: "Books", slug: "books" },
+      { name: "Clothing", slug: "clothing" }
+    ]);
+  });
+
+  afterEach(async () => {
+    await categoryModel.deleteMany();
+  });
+
+  describe("Get All Categories Tests", () => {
+    test("should return all categories with correct properties", async () => {
+      const res = await request(app).get("/api/v1/category/get-category");
+      
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toBe("All Categories List");
+      expect(res.body.category).toHaveLength(3);
+
+      res.body.category.forEach(category => {
+        expect(category).toHaveProperty("_id");
+        expect(category).toHaveProperty("name");
+        expect(category).toHaveProperty("slug");
+      });
+    });
+
+    test("should handle empty category list", async () => {
+      await categoryModel.deleteMany();
+      
+      const res = await request(app).get("/api/v1/category/get-category");
+      
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.category).toHaveLength(0);
+    });
+  });
+
+  describe("Get Single Category Tests", () => {
+    test("should return correct category when valid slug is provided", async () => {
+      const res = await request(app).get("/api/v1/category/single-category/electronics");
+      
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.message).toBe("Get Single Category Successfully");
+      expect(res.body.category.name).toBe("Electronics");
+      expect(res.body.category.slug).toBe("electronics");
+    });
+
+    test("should handle non-existent category slug", async () => {
+      const res = await request(app).get("/api/v1/category/single-category/non-existent");
+      
+      expect(res.status).toBe(200);
+      expect(res.body.category).toBeNull();
+    });
+
+    test("should handle special characters in slug", async () => {
+      await categoryModel.create({
+        name: "Baby & Kids",
+        slug: "baby-kids"
+      });
+
+      const res = await request(app).get("/api/v1/category/single-category/baby-kids");
+      
+      expect(res.status).toBe(200);
+      expect(res.body.success).toBe(true);
+      expect(res.body.category.name).toBe("Baby & Kids");
+      expect(res.body.category.slug).toBe("baby-kids");
+    });
+
+    test("should handle case-insensitive slugs correctly", async () => {
+      const res = await request(app).get("/api/v1/category/single-category/ELECTRONICS");
+      
+      // Should return electronics category
+      expect(res.status).toBe(200);
+      expect(res.body.category.name).toBe("Electronics");
+      expect(res.body.category.slug).toBe("electronics");
+    });
+  });
+
+  describe("Category Response Performance Tests", () => {
+    test("should handle large number of categories efficiently", async () => {
+      const bulkCategories = Array.from({ length: 100 }, (_, i) => ({
+        name: `Test Category ${i}`,
+        slug: `test-category-${i}`
+      }));
+      await categoryModel.insertMany(bulkCategories);
+
+      const startTime = Date.now();
+      const res = await request(app).get("/api/v1/category/get-category");
+      const endTime = Date.now();
+
+      expect(res.status).toBe(200);
+      expect(res.body.category.length).toBe(103); // 3 og + 100 new
+      expect(endTime - startTime).toBeLessThan(1000); // Response should be under 1 second
+    });
+  });
+});

--- a/controllers/categoryController.integration.test.js
+++ b/controllers/categoryController.integration.test.js
@@ -72,8 +72,9 @@ describe("Category Controller Integration Tests", () => {
     test("should handle non-existent category slug", async () => {
       const res = await request(app).get("/api/v1/category/single-category/non-existent");
       
-      expect(res.status).toBe(200);
-      expect(res.body.category).toBeNull();
+      expect(res.status).toBe(404);
+      expect(res.body.success).toBe(false);
+      expect(res.body.message).toBe("Category not found");
     });
 
     test("should handle special characters in slug", async () => {

--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -82,7 +82,7 @@ export const singleCategoryController = async (req, res) => {
     const category = await categoryModel.findOne({ slug: req.params.slug });
     res.status(200).send({
       success: true,
-      message: "Get SIngle Category SUccessfully",
+      message: "Get Single Category Successfully",
       category,
     });
   } catch (error) {

--- a/controllers/categoryController.js
+++ b/controllers/categoryController.js
@@ -6,17 +6,23 @@ export const createCategoryController = async (req, res) => {
     if (!name) {
       return res.status(401).send({ message: "Name is required" });
     }
-    const existingCategory = await categoryModel.findOne({ name });
+    
+    const trimmedName = name.trim();
+    const existingCategory = await categoryModel.findOne({ 
+      name: { $regex: new RegExp(`^${trimmedName}$`, 'i') }
+    });
     if (existingCategory) {
-      return res.status(200).send({
-        success: true,
+      return res.status(409).send({
+        success: false,
         message: "Category Already Exists",
       });
     }
+
     const category = await new categoryModel({
-      name,
-      slug: slugify(name),
+      name: trimmedName,
+      slug: slugify(trimmedName.toLowerCase()),
     }).save();
+
     res.status(201).send({
       success: true,
       message: "new category created",
@@ -37,14 +43,53 @@ export const updateCategoryController = async (req, res) => {
   try {
     const { name } = req.body;
     const { id } = req.params;
+    const trimmedName = name.trim();
+    
+    // Get current category
+    const currentCategory = await categoryModel.findById(id);
+    if (!currentCategory) {
+      return res.status(404).send({
+        success: false,
+        message: "Category not found",
+      });
+    }
+
+    // If the name hasn't changed (case-insensitive compare), proceed with update
+    if (currentCategory.name.toLowerCase() === trimmedName.toLowerCase()) {
+      const category = await categoryModel.findByIdAndUpdate(
+        id,
+        { name: trimmedName, slug: slugify(trimmedName.toLowerCase()) },
+        { new: true }
+      );
+
+      return res.status(200).send({
+        success: true,
+        message: "Category Updated Successfully",
+        category,
+      });
+    }
+
+    // If name is different, check if it conflicts with any other category
+    const existingCategory = await categoryModel.findOne({ 
+      name: { $regex: new RegExp(`^${trimmedName}$`, 'i') }
+    });
+    
+    if (existingCategory) {
+      return res.status(409).send({
+        success: false,
+        message: "Category name already exists",
+      });
+    }
+    
     const category = await categoryModel.findByIdAndUpdate(
       id,
-      { name, slug: slugify(name) },
+      { name: trimmedName, slug: slugify(trimmedName.toLowerCase()) },
       { new: true }
     );
+
     res.status(200).send({
       success: true,
-      messsage: "Category Updated Successfully",
+      message: "Category Updated Successfully",
       category,
     });
   } catch (error) {
@@ -80,6 +125,14 @@ export const categoryControlller = async (req, res) => {
 export const singleCategoryController = async (req, res) => {
   try {
     const category = await categoryModel.findOne({ slug: req.params.slug });
+
+    if (!category) {
+      return res.status(404).send({
+        success: false,
+        message: "Category not found",
+      });
+    }
+    
     res.status(200).send({
       success: true,
       message: "Get Single Category Successfully",
@@ -99,7 +152,15 @@ export const singleCategoryController = async (req, res) => {
 export const deleteCategoryCOntroller = async (req, res) => {
   try {
     const { id } = req.params;
-    await categoryModel.findByIdAndDelete(id);
+    const category = await categoryModel.findByIdAndDelete(id);
+
+    if (!category) {
+      return res.status(404).send({
+        success: false,
+        message: "Category not found",
+      });
+    }
+
     res.status(200).send({
       success: true,
       message: "Category Deleted Successfully",


### PR DESCRIPTION
### Fix `categoryController.js`
- Trim category names and do case-insensitive checks to prevent duplicate categories
- Send `409` status code for Category already exists
- Allow updating categories' name case sensitivity, disallows updating a category name to an existing category name

### Tests for updated `categoryController.js`
- Add integration tests for updated `categoryController`
- Updated existing unit tests